### PR TITLE
Removed additional PHP versions so that only a single deploy executes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 php:
 - 5.6
-- 5.5
-- 5.4
 script:
 - phpunit -c tests/phpunit.xml
 deploy:


### PR DESCRIPTION
Travis deploys for each version/target.  As a result, the site would deploy three times (once for php 5.6, 5.5 and 5.4).
